### PR TITLE
switch pattern matching to mustermann

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ class Hello < Nancy::Base
     "Hello #{params['name']}"
   end
 
+  get "/files/:root/*path" do
+    "From #{params['root']}, download #{params['path']}"
+  end
+
   get "/template" do
     @message = "Hello world"
     render("views/hello.erb")
@@ -61,18 +65,17 @@ class Hello < Nancy::Base
     render("views/layout.erb") { render("views/welcome.erb") }
   end
   
-  before do
-    if request.path_info == "/protected" && !session[:authenticated]
-      halt 401, "unauthorized"
-    end
+  before("/protected") do
+    halt 401, "unauthorized" unless session[:authenticated]
   end
 
   get "/protected" do
     "Protected area!!!"
   end
   
-  after do
-    if request.path_info ~= /\.json$/
+  after(".{+extension}") do |params|
+    case params['extension']
+    when 'json'
       response['Content-Type'] = 'application/json'
     else
       response['Content-Type'] = 'text/html'

--- a/lib/nancy/base.rb
+++ b/lib/nancy/base.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'mustermann'
 require 'rack'
 
 module Nancy
@@ -37,12 +38,7 @@ module Nancy
       private
 
       def compile(pattern)
-        keys = []
-        pattern.gsub!(/(:\w+)/) do |match|
-          keys << $1[1..-1]
-          "([^/?#]+)"
-        end
-        [%r{^#{pattern}$}, keys]
+        Mustermann.new(pattern)
       end
 
       def builder
@@ -82,19 +78,19 @@ module Nancy
     def route_eval
       catch(:halt) do
         self.class.route_set[request.request_method].each do |matcher, block|
-          if match = request.path_info.match(matcher[0])
-            if (captures = match.captures) && !captures.empty?
-              url_params = Hash[*matcher[1].zip(captures).flatten]
-              @params = url_params.merge(params)
-            end
-            instance_exec(&self.class.filters[:before]) if self.class.filters[:before]
-            response.write instance_eval(&block)
-            instance_exec(&self.class.filters[:after]) if self.class.filters[:after]
-            return
-          end
+          next unless url_params = matcher.params(request.path_info)
+          @params = url_params.merge(params)
+          return action_eval(block)
         end
         halt 404
       end
     end
+
+    def action_eval(block)
+      instance_exec(&self.class.filters[:before]) if self.class.filters[:before]
+      response.write instance_eval(&block)
+      instance_exec(&self.class.filters[:after]) if self.class.filters[:after]
+    end
+
   end
 end

--- a/lib/nancy/version.rb
+++ b/lib/nancy/version.rb
@@ -1,3 +1,3 @@
 module Nancy
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/nancy.gemspec
+++ b/nancy.gemspec
@@ -2,8 +2,8 @@
 require File.expand_path('../lib/nancy/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Guillermo Iguaran"]
-  gem.email         = ["guilleiguaran@gmail.com"]
+  gem.authors       = ["Guillermo Iguaran", "Jon Raphaelson"]
+  gem.email         = ["guilleiguaran@gmail.com", "jon@accidental.cc"]
   gem.description   = %q{Sinatra's little daughter}
   gem.summary       = %q{Ruby Microframework inspired in Sinatra}
   gem.homepage      = "http://guilleiguaran.github.com/nancy"
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Nancy::VERSION
 
   gem.add_dependency 'rack'
+  gem.add_dependency 'mustermann'
   gem.add_development_dependency 'tilt'
   gem.add_development_dependency 'erubis'
   gem.add_development_dependency 'minitest'

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -14,6 +14,14 @@ class BaseTest < Minitest::Test
       "Hello #{params['name']}"
     end
 
+    get "/splat/*string" do
+      "Splat #{params['string']}"
+    end
+
+    get "/optional(/:id)?" do
+      "Optional #{params['id'] || 'not provided'}"
+    end
+
     post "/hello" do
       "Hello #{params['name']}"
     end
@@ -56,6 +64,22 @@ class BaseTest < Minitest::Test
   def test_url_params
     get '/hello/user'
     assert_equal 'Hello user', last_response.body
+  end
+
+  def test_splat_params
+    get '/splat/foo/bar/baz'
+    assert_equal 'Splat foo/bar/baz', last_response.body
+  end
+
+  def test_optional_params
+    get '/optional'
+    assert_equal 'Optional not provided', last_response.body
+
+    get '/optional/4'
+    assert_equal 'Optional 4', last_response.body
+
+    get '/optional/'
+    assert_equal 404, last_response.status
   end
 
   def test_post_params

--- a/test/filters_test.rb
+++ b/test/filters_test.rb
@@ -4,8 +4,34 @@ class FiltersTest < Minitest::Test
   include Rack::Test::Methods
 
   class TestApp < Nancy::Base
+    before("/protected") do
+      halt 401, "unauthorized"
+    end
+
+    before("/object/:id") do |params|
+      @object = params["id"]
+    end
+
+    before("/splat/:root/*.*") do |params|
+      @root = params["root"]
+      @path = params["splat"][0]
+      @ext  = params["splat"][1]
+    end
+
     before do
-      halt 401, "unauthorized" if request.path_info == "/protected"
+      response.write "1 "
+    end
+
+    before do
+      response.write "2 "
+    end
+
+    after do
+      response.write " 3"
+    end
+
+    after do
+      response.write " 4"
     end
 
     after do
@@ -18,6 +44,14 @@ class FiltersTest < Minitest::Test
 
     get "/protected" do
       "This is protected!!"
+    end
+
+    get "/object/*" do
+      "Looking at #{@object}"
+    end
+
+    get "/splat/*" do
+      "root #{@root} path #{@path} ext #{@ext}"
     end
   end
 
@@ -34,6 +68,16 @@ class FiltersTest < Minitest::Test
   def test_after_filter
     get '/'
     assert_equal 'application/json', last_response.headers['Content-Type']
-    assert_equal %q({"message":"hello world"}), last_response.body
+    assert_equal %q(1 2 {"message":"hello world"} 4 3), last_response.body
+  end
+
+  def test_before_filter_params
+    get '/object/49'
+    assert_equal "1 2 Looking at 49 4 3", last_response.body
+  end
+
+  def test_before_filter_params_multiple_arguments
+    get '/splat/foo/file.png'
+    assert_equal "1 2 root foo path file ext png 4 3", last_response.body
   end
 end


### PR DESCRIPTION
Switch route pattern matching to [sinatra/mustermann](https://github.com/sinatra/mustermann), which provides a bunch of new routing primitives.

* switch `Nancy::Base` to do routing with Mustermann
* extract `Nancy::Base#action_eval` to make overriding `#route_eval` easier in subclasses
* enhance filters to handle multiple blocks per type, and take route patterns as condition
* extract `Nancy::Base#filter_eval` to make overriding `#action_eval` easier in subclasses
* bump version to `0.5.0`, since the pattern matching DSL has fundamentally changed

All existing tests pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/guilleiguaran/nancy/3)
<!-- Reviewable:end -->
