### PR TITLE
force "standard" (rubocop ruleset) to 1.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 require:
   - standard
+  - rubocop-minitest
+  - rubocop-rake
 
 inherit_gem:
   standard: config/base.yml
@@ -25,3 +27,11 @@ Layout/EmptyLinesAroundModuleBody:
 
 Layout/ExtraSpacing:
   AllowForAlignment: true
+
+# minitest is really picky about newlines
+
+Minitest/EmptyLineBeforeAssertionMethods:
+  Enabled: false
+
+Minitest/MultipleAssertions:
+  Max: 5

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gemspec
 gem "minitest"
 gem "rack-test"
 gem "rake"
-gem "standard" # rubocop ruleset
+gem "standard", ">= 1" # rubocop ruleset
 gem "rubocop"
 gem "rubocop-minitest"
 gem "rubocop-rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 #!/usr/bin/env rake
 require "rake/testtask"
 
+desc "run tests"
 task :test do
   Dir.chdir("test")
 end

--- a/lib/nancy/base.rb
+++ b/lib/nancy/base.rb
@@ -68,7 +68,7 @@ module Nancy
 
     def halt(*res)
       response.status = res.detect { |x| x.is_a?(Integer) } || 200
-      response.header.merge!(res.detect { |x| x.is_a?(Hash) } || {})
+      response.headers.merge!(res.detect { |x| x.is_a?(Hash) } || {})
       response.body = [res.detect { |x| x.is_a?(String) } || ""]
       throw :halt, response
     end

--- a/nancy.gemspec
+++ b/nancy.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |gem|
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "nancy"
   gem.require_paths = ["lib"]
   gem.version       = Nancy::VERSION

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -54,9 +54,13 @@ class BaseTest < Minitest::Test
   end
 
   def test_app_respond_with_call
-    assert TestApp.new.respond_to?(:call)
+    assert_respond_to TestApp.new, :call
+  end
+
+  def test_basic_call
     request = Rack::MockRequest.new(TestApp.new)
     response = request.get("/")
+
     assert_equal 200, response.status
     assert_equal "Hello World", response.body
   end
@@ -95,7 +99,7 @@ class BaseTest < Minitest::Test
   def test_redirect
     get "/redirect"
     follow_redirect!
-    assert last_response.body.include?("Redirected")
+    assert_includes last_response.body, "Redirected"
   end
 
   def test_halting

--- a/test/basic_render_test.rb
+++ b/test/basic_render_test.rb
@@ -28,13 +28,15 @@ class BasicRenderTest < Minitest::Test
 
   def test_render
     get "/view"
-    assert !last_response.body.include?("<html>")
-    assert last_response.body.include?("Hello from view")
+
+    refute_includes last_response.body, "<html>"
+    assert_includes last_response.body, "Hello from view"
   end
 
   def test_render_with_layout
     get "/layout"
-    assert last_response.body.include?("<html>")
-    assert last_response.body.include?("Hello from view")
+
+    assert_includes last_response.body, "<html>"
+    assert_includes last_response.body, "Hello from view"
   end
 end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -32,14 +32,16 @@ class RenderTest < Minitest::Test
 
   def test_render
     get "/view"
-    assert !last_response.body.include?("<html>")
-    assert last_response.body.include?("Hello from view")
+
+    refute_includes last_response.body, "<html>"
+    assert_includes last_response.body, "Hello from view"
   end
 
   def test_render_with_layout
     get "/layout"
-    assert last_response.body.include?("<html>")
-    assert last_response.body.include?("Hello from view")
+
+    assert_includes last_response.body, "<html>"
+    assert_includes last_response.body, "Hello from view"
   end
 
   def test_send_tilt_options_to_render

--- a/test/use_test.rb
+++ b/test/use_test.rb
@@ -21,8 +21,9 @@ end
 
 class UseTest < Minitest::Test
   def test_use
-    request = Rack::MockRequest.new(HelloApp.new)
+    request  = Rack::MockRequest.new(HelloApp.new)
     response = request.get("/")
+
     assert_equal "dlroW olleH", response.body
   end
 end


### PR DESCRIPTION
due to some versioning shenanigans, we need to explicitly mark `standard` as being `>= 1` 

message from bundle output below:

https://github.com/standardrb/standard/issues/340#issuecomment-1495865047

> Versions of Standard prior to 0.0.37 depended on `>= 0.63' of RuboCop, which means that Bundler continues to resolve to those (now ancient) versions whenever `gem "standard"' is added to a Gemfile that has already locked to a newer version of RuboCop than standard currently depends on.
> 
> "How do I fix this?", you might be asking.
> 
> How to fix this
> ---------------
> If you add a version specifier pinning `standard' to a version newer than 0.0.36.1, Bundler will resolve appropriate versions of `standard', `rubocop', and any other rubocop-dependent gems you may have installed.