### PR TITLE
fix rack/session with rack 3

### DIFF
--- a/lib/nancy/base.rb
+++ b/lib/nancy/base.rb
@@ -68,7 +68,7 @@ module Nancy
 
     def halt(*res)
       response.status = res.detect { |x| x.is_a?(Integer) } || 200
-      response.header.merge!(res.detect { |x| x.is_a?(Hash) } || {})
+      response.headers.merge!(res.detect { |x| x.is_a?(Hash) } || {})
       response.body = [res.detect { |x| x.is_a?(String) } || ""]
       throw :halt, response
     end

--- a/nancy.gemspec
+++ b/nancy.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.7", "< 4"
 
   gem.add_dependency "rack"
+  gem.add_dependency "rack-session"
   gem.add_dependency "mustermann"
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,10 +1,13 @@
 require File.expand_path("../test_helper", __FILE__)
 
+require "rack/session"
+require "securerandom"
+
 class BaseTest < Minitest::Test
   include Rack::Test::Methods
 
   class TestApp < Nancy::Base
-    use Rack::Session::Cookie, secret: "secret"
+    use Rack::Session::Cookie, secret: SecureRandom.hex(64)
 
     get "/" do
       "Hello World"


### PR DESCRIPTION
rack/session was moved out of rack in rack 3, to a separate gem, and a few methods were deprecated. with this change, tests all pass.